### PR TITLE
Exclude object method from UselessMethod rule

### DIFF
--- a/rubocop_base_config.yml
+++ b/rubocop_base_config.yml
@@ -123,6 +123,8 @@ Lint/UnmodifiedReduceAccumulator: # new in 1.1
   Enabled: true  
 Lint/UselessMethodDefinition: # (new in 0.90)
   Enabled: true
+  IgnoredMethods:
+    - object
 Lint/UselessRuby2Keywords: # new in 1.23
   Enabled: true  
 Lint/UselessTimes: # (new in 0.91)


### PR DESCRIPTION
In some cases (e.g. serializers), a "useless" `object` method can be used to assist the IDE with type inference. For example:
```ruby
# @return [PublisherInvitation]
def object
  super
end
```
This tells RubyMine that the type of the `object` being serialized is a `PublisherInvitation`. Without this method, RubyMine is not able to resolve the type of the `object`