### PR TITLE
Revert IgnoredMethods attribute from Lint/UselessMethodDefinition rule

### DIFF
--- a/rubocop_base_config.yml
+++ b/rubocop_base_config.yml
@@ -146,8 +146,6 @@ Lint/UnreachableLoop: # (new in 0.89)
   Enabled: true
 Lint/UselessMethodDefinition: # (new in 0.90)
   Enabled: true
-  IgnoredMethods:
-    - object
 Lint/UselessRescue: # new in 1.43
   Enabled: true
 Lint/UselessRuby2Keywords: # new in 1.23


### PR DESCRIPTION
Reverts #9 

The `Lint/UselessMethodDefinition` rule does not seem to support the `Lint/UselessMethodDefinition` rule, so this change did not have any effect.