### PR TITLE
CAI-21: Update RuboCop to 1.78

### DIFF
--- a/rubocop_base_config.yml
+++ b/rubocop_base_config.yml
@@ -6,6 +6,10 @@ AllCops:
 Bundler/OrderedGems:
   Enabled: false
 
+Gemspec/AddRuntimeDependency: # new in 1.65
+  Enabled: true
+Gemspec/AttributeAssignment: # new in 1.77
+  Enabled: true
 Gemspec/DeprecatedAttributeAssignment: # new in 1.30
   Enabled: true
 Gemspec/DevelopmentDependencies: # new in 1.44
@@ -53,11 +57,17 @@ Lint/AmbiguousOperatorPrecedence: # new in 1.21
   Enabled: true
 Lint/AmbiguousRange: # new in 1.19
   Enabled: true
+Lint/ArrayLiteralInRegexp: # new in 1.71
+  Enabled: true
 Lint/BinaryOperatorWithIdenticalOperands: # (new in 0.89)
   Enabled: true
 Lint/ConstantDefinitionInBlock: # (new in 0.91)
   Enabled: true
 Lint/ConstantOverwrittenInRescue: # new in 1.31
+  Enabled: true
+Lint/ConstantReassignment: # new in 1.70
+  Enabled: true
+Lint/CopDirectiveSyntax: # new in 1.72
   Enabled: true
 Lint/DeprecatedConstants: # new in 1.8
   Enabled: true
@@ -77,6 +87,8 @@ Lint/DuplicateRequire: # (new in 0.90)
   Enabled: true
 Lint/DuplicateRescueException: # (new in 0.89)
   Enabled: true
+Lint/DuplicateSetElement: # new in 1.67
+  Enabled: true
 Lint/EmptyBlock: # new in 1.1
   Enabled: true
 Lint/EmptyClass: # new in 1.3
@@ -90,11 +102,17 @@ Lint/EmptyInPattern: # new in 1.16
   Enabled: true
 Lint/FloatComparison: # (new in 0.89)
   Enabled: true
+Lint/HashNewWithKeywordArgumentsAsDefault: # new in 1.69
+  Enabled: true
 Lint/IdentityComparison: # (new in 0.91)
   Enabled: true
 Lint/IncompatibleIoSelectWithFiberScheduler: # new in 1.21
   Enabled: true
+Lint/ItWithoutArgumentsInBlock: # new in 1.59
+  Enabled: true
 Lint/LambdaWithoutLiteralBlock: # new in 1.8
+  Enabled: true
+Lint/LiteralAssignmentInCondition: # new in 1.58
   Enabled: true
 Lint/MissingSuper: # (new in 0.89)
   Enabled: true
@@ -108,6 +126,8 @@ Lint/NoReturnInBeginEndBlocks: # new in 1.2
   Enabled: true
 Lint/NumberedParameterAssignment: # new in 1.9
   Enabled: true
+Lint/NumericOperationWithConstantResult: # new in 1.69
+  Enabled: true
 Lint/OrAssignmentToConstant: # new in 1.9
   Enabled: true
 Lint/OutOfRangeRegexpRef: # (new in 0.89)
@@ -118,6 +138,8 @@ Lint/RedundantDirGlobSort: # new in 1.8
   Enabled: true
 Lint/RedundantRegexpQuantifiers: # new in 1.53
   Enabled: true
+Lint/RedundantTypeConversion: # new in 1.72
+  Enabled: true
 Lint/RefinementImportMethods: # new in 1.27
   Enabled: true
 Lint/RequireRangeParentheses: # new in 1.32
@@ -126,7 +148,11 @@ Lint/RequireRelativeSelfPath: # new in 1.22
   Enabled: true
 Lint/SelfAssignment: # (new in 0.89)
   Enabled: true
+Lint/SharedMutableDefault: # new in 1.70
+  Enabled: true
 Lint/StructNewOverride: # (new in 0.81)
+  Enabled: true
+Lint/SuppressedExceptionInNumberConversion: # new in 1.72
   Enabled: true
 Lint/SymbolConversion: # new in 1.9
   Enabled: true
@@ -138,13 +164,25 @@ Lint/TrailingCommaInAttributeDeclaration: # (new in 0.90)
   Enabled: true
 Lint/TripleQuotes: # new in 1.9
   Enabled: true
+Lint/UnescapedBracketInRegexp: # new in 1.68
+  Enabled: true
 Lint/UnexpectedBlockArity: # new in 1.5
   Enabled: true
 Lint/UnmodifiedReduceAccumulator: # new in 1.1
   Enabled: true
 Lint/UnreachableLoop: # (new in 0.89)
   Enabled: true
+Lint/UselessConstantScoping: # new in 1.72
+  Enabled: true
+Lint/UselessDefaultValueArgument: # new in 1.76
+  Enabled: true
+Lint/UselessDefined: # new in 1.69
+  Enabled: true
 Lint/UselessMethodDefinition: # (new in 0.90)
+  Enabled: true
+Lint/UselessNumericOperation: # new in 1.66
+  Enabled: true
+Lint/UselessOr: # new in 1.76
   Enabled: true
 Lint/UselessRescue: # new in 1.43
   Enabled: true
@@ -176,6 +214,8 @@ Metrics/ParameterLists:
 
 Naming/BlockForwarding: # new in 1.24
   Enabled: true
+Naming/PredicateMethod: # new in 1.76
+  Enabled: true
 
 Security/CompoundHash: # new in 1.28
   Enabled: true
@@ -184,23 +224,35 @@ Security/IoMethods: # new in 1.22
 
 Style/AccessorGrouping: # (new in 0.87)
   Enabled: true
+Style/AmbiguousEndlessMethodDefinition: # new in 1.68
+  Enabled: true
 Style/ArgumentsForwarding: # new in 1.1
   Enabled: true
 Style/ArrayIntersect: # new in 1.40
   Enabled: true
 Style/BisectedAttrAccessor:
   Enabled: true
+Style/BitwisePredicate: # new in 1.68
+  Enabled: true
 Style/CaseLikeIf:
   Enabled: true
 Style/CollectionCompact: # new in 1.2
   Enabled: true
+Style/CollectionQuerying: # new in 1.77
+  Enabled: true
+Style/CombinableDefined: # new in 1.68
+  Enabled: true
 Style/CombinableLoops:
+  Enabled: true
+Style/ComparableBetween: # new in 1.74
   Enabled: true
 Style/ComparableClamp: # new in 1.44
   Enabled: true
 Style/ConcatArrayLiterals: # new in 1.41
   Enabled: true
 Style/DataInheritance: # new in 1.49
+  Enabled: true
+Style/DigChain: # new in 1.69
   Enabled: true
 Style/DirEmpty: # new in 1.48
   Enabled: true
@@ -209,6 +261,8 @@ Style/Documentation:
 Style/DocumentDynamicEvalDefinition: # new in 1.1
   Enabled: true
 Style/EmptyHeredoc: # new in 1.32
+  Enabled: true
+Style/EmptyStringInsideInterpolation: # new in 1.76
   Enabled: true
 Style/EndlessMethod: # new in 1.8
   Enabled: true
@@ -224,7 +278,11 @@ Style/FetchEnvVar: # new in 1.28
   Enabled: true
 Style/FileEmpty: # new in 1.48
   Enabled: true
+Style/FileNull: # new in 1.69
+  Enabled: true
 Style/FileRead: # new in 1.24
+  Enabled: true
+Style/FileTouch: # new in 1.69
   Enabled: true
 Style/FileWrite: # new in 1.24
   Enabled: true
@@ -243,7 +301,11 @@ Style/HashEachMethods: # (new in 0.80)
   Enabled: true
 Style/HashExcept: # new in 1.7
   Enabled: true
+Style/HashFetchChain: # new in 1.75
+  Enabled: true
 Style/HashLikeCase: # (new in 0.88)
+  Enabled: true
+Style/HashSlice: # new in 1.71
   Enabled: true
 Style/HashTransformKeys: # (new in 0.80)
   Enabled: true
@@ -255,6 +317,12 @@ Style/IfWithBooleanLiteralBranches: # new in 1.9
   Enabled: true
 Style/InPatternThen: # new in 1.16
   Enabled: true
+Style/ItAssignment: # new in 1.70
+  Enabled: true
+Style/ItBlockParameter: # new in 1.75
+  Enabled: true
+Style/KeywordArgumentsMerging: # new in 1.68
+  Enabled: true
 Style/KeywordParametersOrder: # (new in 0.90)
   Enabled: true
 Style/Lambda:
@@ -262,6 +330,8 @@ Style/Lambda:
 Style/MagicCommentFormat: # new in 1.35
   Enabled: true
 Style/MapCompactWithConditionalBlock: # new in 1.30
+  Enabled: true
+Style/MapIntoArray: # new in 1.63
   Enabled: true
 Style/MapToHash: # new in 1.24
   Enabled: true
@@ -303,6 +373,8 @@ Style/RedundantArgument: # new in 1.4
   Enabled: true
 Style/RedundantArrayConstructor: # new in 1.52
   Enabled: true
+Style/RedundantArrayFlatten: # new in 1.76
+  Enabled: true
 Style/RedundantAssignment: # (new in 0.87)
   Enabled: true
 Style/RedundantConstantBase: # new in 1.40
@@ -319,9 +391,13 @@ Style/RedundantFileExtensionInRequire: # (new in 0.88)
   Enabled: true
 Style/RedundantFilterChain: # new in 1.52
   Enabled: true
+Style/RedundantFormat: # new in 1.72
+  Enabled: true
 Style/RedundantHeredocDelimiterQuotes: # new in 1.45
   Enabled: true
 Style/RedundantInitialize: # new in 1.27
+  Enabled: true
+Style/RedundantInterpolationUnfreeze: # new in 1.66
   Enabled: true
 Style/RedundantLineContinuation: # new in 1.49
   Enabled: true
@@ -343,7 +419,11 @@ Style/RegexpLiteral:
   AllowInnerSlashes: true
 Style/ReturnNilInPredicateMethodDefinition: # new in 1.53
   Enabled: true
+Style/SafeNavigationChainLength: # new in 1.68
+  Enabled: false
 Style/SelectByRegexp: # new in 1.22
+  Enabled: true
+Style/SendWithLiteralMethodName: # new in 1.64
   Enabled: true
 Style/SingleArgumentDig: # (new in 0.89)
   Enabled: true
@@ -356,6 +436,10 @@ Style/SoleNestedConditional: # (new in 0.89)
 Style/StringChars: # new in 1.12
   Enabled: true
 Style/StringConcatenation: # (new in 0.89)
+  Enabled: true
+Style/SuperArguments: # new in 1.64
+  Enabled: true
+Style/SuperWithArgsParentheses: # new in 1.58
   Enabled: true
 Style/SwapValues: # new in 1.1
   Enabled: true


### PR DESCRIPTION
[CAI-21](https://safesoftware.atlassian.net/browse/CAI-21)

Updating RuboCop config from version **1.57.2** to **1.78**.

- Adds all the new cops introduced between those versions, enabling or disabling them based on [team discussion](https://docs.google.com/document/d/1wm3uggNRNA72_2KYY3cZZsnUg_WITLxKMtdR177KaaU/edit?usp=sharing)